### PR TITLE
Feature/lw streamline conceptmapping

### DIFF
--- a/cmd/fenix/fhir/conceptmap/converter.go
+++ b/cmd/fenix/fhir/conceptmap/converter.go
@@ -3,6 +3,7 @@ package conceptmap
 
 import (
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -232,4 +233,39 @@ func (c *ConceptMapConverter) finalizeGroups(groupMap map[string]*fhir.ConceptMa
 		groups = append(groups, *group)
 	}
 	return groups
+}
+
+func (s *ConceptMapService) CreateConceptMap(id string, name string, sourceValueSet string, targetValueSet string) *fhir.ConceptMap {
+	url := fmt.Sprintf("http://localhost/fhir/ConceptMap/%s", id)
+
+	return &fhir.ConceptMap{
+		Id:        &id,
+		Url:       &url,
+		Name:      &name,
+		Status:    1,
+		Date:      stringPtr(time.Now().Format(time.RFC3339)),
+		SourceUri: &sourceValueSet,
+		TargetUri: &targetValueSet,
+		Group:     []fhir.ConceptMapGroup{},
+	}
+}
+
+// Add this method to your existing conceptmap/service.go file
+func (s *ConceptMapService) SaveConceptMap(outputPath string, cm *fhir.ConceptMap) error {
+	data, err := json.MarshalIndent(cm, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal ConceptMap: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
+		return fmt.Errorf("failed to create directories: %w", err)
+	}
+
+	if err := os.WriteFile(outputPath, data, 0644); err != nil {
+		s.log.Error().Err(err).Str("path", outputPath).Msg("Failed to write ConceptMap to file")
+		return fmt.Errorf("failed to write ConceptMap file: %w", err)
+	}
+
+	s.log.Debug().Str("path", outputPath).Msg("Successfully saved ConceptMap")
+	return nil
 }

--- a/cmd/fenix/fhir/conceptmap/converter.go
+++ b/cmd/fenix/fhir/conceptmap/converter.go
@@ -151,11 +151,8 @@ func (c *ConceptMapConverter) ConvertCSVToFHIRAndSave(reader io.Reader, csvName 
 	}
 
 	// Add to repository cache
-	if conceptMap.Id != nil {
-		repository.cache.Store(*conceptMap.Id, conceptMap)
-	}
-	if conceptMap.TargetUri != nil {
-		repository.cache.Store(*conceptMap.TargetUri, conceptMap)
+	if conceptMap.Url != nil {
+		repository.cache.Store(*conceptMap.Url, conceptMap)
 	}
 
 	return nil

--- a/cmd/fenix/fhir/conceptmap/converter.go
+++ b/cmd/fenix/fhir/conceptmap/converter.go
@@ -141,13 +141,12 @@ func (c *ConceptMapConverter) ConvertCSVToFHIRAndSave(reader io.Reader, csvName 
 	conceptMap.Group = c.finalizeGroups(groupMap)
 
 	// Create the fhir/converted directory within the repository's local path
-	outputPath := filepath.Join(repository.localPath, "fhir", "converted")
-	if err := os.MkdirAll(outputPath, 0755); err != nil {
+	if err := os.MkdirAll(repository.localPath, 0755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 
 	// Save with original CSV name (minus extension) plus .json
-	outputFile := filepath.Join(outputPath, baseName+".json")
+	outputFile := filepath.Join(repository.localPath, baseName+".json")
 	if err := c.conceptMapService.SaveConceptMap(outputFile, conceptMap); err != nil {
 		return fmt.Errorf("failed to save ConceptMap: %w", err)
 	}

--- a/cmd/fenix/fhir/conceptmap/converter.go
+++ b/cmd/fenix/fhir/conceptmap/converter.go
@@ -17,7 +17,6 @@ import (
 )
 
 // ConceptMapConverter handles conversion of mapping files to FHIR ConceptMaps
-// ConceptMapConverter handles conversion of mapping files to FHIR ConceptMaps
 type ConceptMapConverter struct {
 	log           zerolog.Logger
 	baseDir       string

--- a/cmd/fenix/fhir/conceptmap/converter.go
+++ b/cmd/fenix/fhir/conceptmap/converter.go
@@ -3,7 +3,6 @@ package conceptmap
 
 import (
 	"encoding/csv"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -160,47 +159,6 @@ func (c *ConceptMapConverter) ConvertCSVToFHIRAndSave(reader io.Reader, csvName 
 	}
 
 	return nil
-}
-
-// ConvertCSVToFHIR maintains backwards compatibility while using the repository structure
-func (c *ConceptMapConverter) ConvertCSVToFHIR(reader io.Reader, name string) (*fhir.ConceptMap, error) {
-
-	// Create a temporary repository
-	tempDir, err := os.MkdirTemp("", "conceptmap_*")
-	if err != nil {
-		return nil, fmt.Errorf("failed to create temp directory: %w", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	tempRepo := NewConceptMapRepository(tempDir, c.conceptMapService.log)
-
-	if err := c.ConvertCSVToFHIRAndSave(reader, name, tempRepo, false); err != nil {
-		return nil, err
-	}
-
-	// Read the saved file
-	convertedPath := filepath.Join(tempDir, "fhir", "converted")
-	files, err := os.ReadDir(convertedPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read converted directory: %w", err)
-	}
-
-	if len(files) == 0 {
-		return nil, fmt.Errorf("no ConceptMap file was created")
-	}
-
-	data, err := os.ReadFile(filepath.Join(convertedPath, files[0].Name()))
-	if err != nil {
-		c.log.Fatal().Err(err).Msg("Failed to read ConceptMap file")
-		return nil, fmt.Errorf("failed to read ConceptMap file: %w", err)
-	}
-
-	var conceptMap fhir.ConceptMap
-	if err := json.Unmarshal(data, &conceptMap); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal ConceptMap: %w", err)
-	}
-
-	return &conceptMap, nil
 }
 
 // extractMapping creates a CSVMapping from a CSV row

--- a/cmd/fenix/fhir/conceptmap/converter.go
+++ b/cmd/fenix/fhir/conceptmap/converter.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/SanteonNL/fenix/models/fhir"
+	"github.com/SanteonNL/fenix/util"
 	"github.com/rs/zerolog"
 )
 
@@ -243,7 +244,7 @@ func (s *ConceptMapService) CreateConceptMap(id string, name string, sourceValue
 		Url:       &url,
 		Name:      &name,
 		Status:    1,
-		Date:      stringPtr(time.Now().Format(time.RFC3339)),
+		Date:      util.StringPtr(time.Now().Format(time.RFC3339)),
 		SourceUri: &sourceValueSet,
 		TargetUri: &targetValueSet,
 		Group:     []fhir.ConceptMapGroup{},

--- a/cmd/fenix/fhir/conceptmap/converter.go
+++ b/cmd/fenix/fhir/conceptmap/converter.go
@@ -30,6 +30,7 @@ func NewConceptMapConverter(log zerolog.Logger, conceptMapService *ConceptMapSer
 	}
 }
 
+// TODO: add check if csv is already converted
 // ConvertFolderToFHIR converts all CSV files in a folder to FHIR ConceptMaps
 func (c *ConceptMapConverter) ConvertFolderToFHIR(inputFolder string, repository *ConceptMapRepository, usePrefix bool) error {
 	files, err := os.ReadDir(inputFolder)

--- a/cmd/fenix/fhir/conceptmap/converter.go
+++ b/cmd/fenix/fhir/conceptmap/converter.go
@@ -236,6 +236,7 @@ func (c *ConceptMapConverter) finalizeGroups(groupMap map[string]*fhir.ConceptMa
 	return groups
 }
 
+// TODO: make this work on the repository?
 func (s *ConceptMapService) CreateConceptMap(id string, name string, sourceValueSet string, targetValueSet string) *fhir.ConceptMap {
 	url := fmt.Sprintf("http://localhost/fhir/ConceptMap/%s", id)
 
@@ -251,6 +252,7 @@ func (s *ConceptMapService) CreateConceptMap(id string, name string, sourceValue
 	}
 }
 
+// TODO make this work on the repository?
 // Add this method to your existing conceptmap/service.go file
 func (s *ConceptMapService) SaveConceptMap(outputPath string, cm *fhir.ConceptMap) error {
 	data, err := json.MarshalIndent(cm, "", "  ")

--- a/cmd/fenix/fhir/conceptmap/converter.go
+++ b/cmd/fenix/fhir/conceptmap/converter.go
@@ -90,7 +90,7 @@ func (c *ConceptMapConverter) ConvertCSVToFHIRAndSave(reader io.Reader, csvName 
 	baseName := strings.TrimSuffix(csvName, filepath.Ext(csvName))
 
 	// Create initial ConceptMap
-	conceptMap := c.conceptMapService.CreateConceptMap(
+	conceptMap := c.CreateConceptMap(
 		fmt.Sprintf("%s_%s", baseName, time.Now().Format("20060102")),
 		baseName,
 		"", // Will be populated from first row
@@ -148,7 +148,7 @@ func (c *ConceptMapConverter) ConvertCSVToFHIRAndSave(reader io.Reader, csvName 
 
 	// Save with original CSV name (minus extension) plus .json
 	outputFile := filepath.Join(repository.localPath, baseName+".json")
-	if err := c.conceptMapService.SaveConceptMap(outputFile, conceptMap); err != nil {
+	if err := c.SaveConceptMap(outputFile, conceptMap); err != nil {
 		return fmt.Errorf("failed to save ConceptMap: %w", err)
 	}
 
@@ -236,8 +236,7 @@ func (c *ConceptMapConverter) finalizeGroups(groupMap map[string]*fhir.ConceptMa
 	return groups
 }
 
-// TODO: make this work on the repository?
-func (s *ConceptMapService) CreateConceptMap(id string, name string, sourceValueSet string, targetValueSet string) *fhir.ConceptMap {
+func (c *ConceptMapConverter) CreateConceptMap(id string, name string, sourceValueSet string, targetValueSet string) *fhir.ConceptMap {
 	url := fmt.Sprintf("http://localhost/fhir/ConceptMap/%s", id)
 
 	return &fhir.ConceptMap{
@@ -252,9 +251,8 @@ func (s *ConceptMapService) CreateConceptMap(id string, name string, sourceValue
 	}
 }
 
-// TODO make this work on the repository?
 // Add this method to your existing conceptmap/service.go file
-func (s *ConceptMapService) SaveConceptMap(outputPath string, cm *fhir.ConceptMap) error {
+func (c *ConceptMapConverter) SaveConceptMap(outputPath string, cm *fhir.ConceptMap) error {
 	data, err := json.MarshalIndent(cm, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal ConceptMap: %w", err)
@@ -265,10 +263,10 @@ func (s *ConceptMapService) SaveConceptMap(outputPath string, cm *fhir.ConceptMa
 	}
 
 	if err := os.WriteFile(outputPath, data, 0644); err != nil {
-		s.log.Error().Err(err).Str("path", outputPath).Msg("Failed to write ConceptMap to file")
+		c.log.Error().Err(err).Str("path", outputPath).Msg("Failed to write ConceptMap to file")
 		return fmt.Errorf("failed to write ConceptMap file: %w", err)
 	}
 
-	s.log.Debug().Str("path", outputPath).Msg("Successfully saved ConceptMap")
+	c.log.Debug().Str("path", outputPath).Msg("Successfully saved ConceptMap")
 	return nil
 }

--- a/cmd/fenix/fhir/conceptmap/repository.go
+++ b/cmd/fenix/fhir/conceptmap/repository.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// TODO add source or target in function names to make it more clear what the function does
 // ConceptMapRepository handles loading and storing ConceptMap resources.
 type ConceptMapRepository struct {
 	log         zerolog.Logger
@@ -29,8 +30,13 @@ func NewConceptMapRepository(localPath string, log zerolog.Logger) *ConceptMapRe
 	}
 }
 
-// LoadConceptMaps loads all ConceptMaps into the repository.
-func (repo *ConceptMapRepository) LoadConceptMaps() error {
+// LoadConceptMapsIntoRepository loads all ConceptMaps into the repository.
+func (repo *ConceptMapRepository) LoadConceptMapsIntoRepository() error {
+	if _, err := os.Stat(repo.localPath); os.IsNotExist(err) {
+		repo.log.Warn().Str("path", repo.localPath).Msg("ConceptMap directory does not exist")
+		return nil
+	}
+
 	files, err := os.ReadDir(repo.localPath)
 	if err != nil {
 		repo.log.Error().Err(err).Msg("Failed to read directory")
@@ -42,7 +48,7 @@ func (repo *ConceptMapRepository) LoadConceptMaps() error {
 			filePath := filepath.Join(repo.localPath, file.Name())
 			repo.log.Debug().Str("filePath", filePath).Msg("Loading ConceptMap file")
 
-			conceptMap, err := repo.loadConceptMapFile(filePath)
+			conceptMap, err := repo.readConceptMapFromFile(filePath)
 			if err != nil {
 				repo.log.Error().
 					Err(err).
@@ -63,10 +69,12 @@ func (repo *ConceptMapRepository) LoadConceptMaps() error {
 			}
 
 			if conceptMap.TargetUri != nil {
-				repo.cache.Store(*conceptMap.TargetUri, conceptMap)
-				repo.log.Debug().
-					Str("targetUri", *conceptMap.TargetUri).
-					Msg("Loaded ConceptMap into cache by TargetUri")
+				if *conceptMap.TargetUri != "" {
+					repo.cache.Store(*conceptMap.TargetUri, conceptMap)
+					repo.log.Debug().
+						Str("targetUri", *conceptMap.TargetUri).
+						Msg("Loaded ConceptMap into cache by TargetUri")
+				}
 			} else {
 				repo.log.Warn().
 					Str("file", file.Name()).
@@ -80,9 +88,10 @@ func (repo *ConceptMapRepository) LoadConceptMaps() error {
 }
 
 // loadConceptMapFile loads a ConceptMap from a file.
-func (repo *ConceptMapRepository) loadConceptMapFile(filePath string) (*fhir.ConceptMap, error) {
+func (repo *ConceptMapRepository) readConceptMapFromFile(filePath string) (*fhir.ConceptMap, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
+		// TODO check of tis should be fatal or Error (in the GetOrLoadConceptMap function it is an error)
 		repo.log.Fatal().Err(err).Str("path", filePath).Msg("Failed to read ConceptMap file")
 		return nil, fmt.Errorf("failed to read ConceptMap file: %w", err)
 	}
@@ -95,14 +104,21 @@ func (repo *ConceptMapRepository) loadConceptMapFile(filePath string) (*fhir.Con
 	return &conceptMap, nil
 }
 
-// GetConceptMap retrieves a ConceptMap by ID or URL.
-func (repo *ConceptMapRepository) GetConceptMap(url string) (*fhir.ConceptMap, error) {
+// GetOrLoadConceptMap retrieves a ConceptMap by URL, loading it from disk if not already in cache.
+func (repo *ConceptMapRepository) GetOrLoadConceptMap(url string) (*fhir.ConceptMap, error) {
 
 	// Try cache first
 	if cached, ok := repo.cache.Load(url); ok {
 		return cached.(*fhir.ConceptMap), nil
 	}
 
+	// Load from disk if not in cache
+	// TOOD: Ask why this is needed; because the cache should be loaded with all ConceptMaps if first in the main all conceptmaps
+	// are loaded from disk and next all converted conceptmaps are also loaded from disk
+	// It might however be usefull if you do not want to load all conceptmaps at once but only the ones you need (and load them only once)
+	// Also the function GetConceptMapFileNameByURL uses readConceptMapFromFile  so it seems a bit circular...
+	// Beacuse it needs to read the conceptmap to determine the filename. Soe maybe jsut let GetConceptMapFileNameByURL
+	// return the conceptmap and not the filename
 	fileName, err := repo.GetConceptMapFileNameByURL(url)
 	if err != nil {
 		return nil, err
@@ -110,46 +126,47 @@ func (repo *ConceptMapRepository) GetConceptMap(url string) (*fhir.ConceptMap, e
 
 	filePath := filepath.Join(repo.localPath, fileName)
 
-	data, err := os.ReadFile(filePath)
+	conceptMap, err := repo.readConceptMapFromFile(filePath)
 	if err != nil {
-		repo.log.Error().Err(err).Str("path", filePath).Msg("Failed to read ConceptMap file")
-		return nil, fmt.Errorf("failed to read ConceptMap file: %w", err)
+		repo.cache.Store(url, conceptMap)
+		return conceptMap, nil
+	} else {
+		return nil, err
 	}
-
-	var conceptMap fhir.ConceptMap
-	if err := json.Unmarshal(data, &conceptMap); err != nil {
-		return nil, fmt.Errorf("failed to parse ConceptMap: %w", err)
-	}
-	repo.cache.Store(url, &conceptMap)
-	return &conceptMap, nil
 }
 
-// GetConceptMapsByValuesetURL retrieves all ConceptMaps with a target URI matching the input URL.
-func (repo *ConceptMapRepository) GetConceptMapsByValuesetURL(valueSetURL string) ([]string, error) {
+// GetConceptMapURLsByValuesetURL retrieves all ConceptMaps with a target URI matching the input URL.
+func (repo *ConceptMapRepository) GetConceptMapURLsByValuesetURL(valueSetURL string) ([]string, error) {
 	var matchingConceptMapURLs []string
 
 	repo.cache.Range(func(key, value interface{}) bool {
+		repo.log.Debug().Str("key", key.(string)).Msg("Checking ConceptMap for ValueSet URL")
 		conceptMap := value.(*fhir.ConceptMap)
 		if conceptMap.TargetUri != nil && *conceptMap.TargetUri == valueSetURL {
+			repo.log.Debug().Str("Adding ConceptMap URL", *conceptMap.Url).Msg("Found matching ConceptMap")
 			matchingConceptMapURLs = append(matchingConceptMapURLs, *conceptMap.Url)
 		}
 		return true
 	})
 
 	if len(matchingConceptMapURLs) == 0 {
-		repo.log.Warn().Str("valueSetURL", valueSetURL).Msg("No ConceptMaps found for ValueSet URL")
-		return nil, fmt.Errorf("no ConceptMaps found for ValueSet URL: %s", valueSetURL)
+		repo.log.Warn().Str("valueSetURL", valueSetURL).Msg("No ConceptMapURLs found for ValueSet URL")
+		return nil, fmt.Errorf("no ConceptMapURLs found for ValueSet URL: %s", valueSetURL)
 	}
 
 	return matchingConceptMapURLs, nil
 }
 
+// TODO check if this function is really needed, it seems not to be used anywhere
 // Helper function to get the file name for a ConceptMap by ID or URL.
 func (repo *ConceptMapRepository) getFileName(key string) string {
 	return fmt.Sprintf("%s.json", key)
 }
 
 // GetConceptMapFileNameByURL returns the filename of a ConceptMap based on its URL
+// This function is only called in the  GetOrLoadConceptMap function but I am not sure it is really needed there
+// It might however be usefull if you do not want to have all conceptmaps loaded at once but only the ones you need
+// TODO check if this function is really neededs
 func (repo *ConceptMapRepository) GetConceptMapFileNameByURL(url string) (string, error) {
 	var matchingFileName string
 	err := filepath.Walk(repo.localPath, func(path string, info os.FileInfo, err error) error {
@@ -162,7 +179,7 @@ func (repo *ConceptMapRepository) GetConceptMapFileNameByURL(url string) (string
 			return nil
 		}
 
-		conceptMap, err := repo.loadConceptMapFile(path)
+		conceptMap, err := repo.readConceptMapFromFile(path)
 		if err != nil {
 			repo.log.Warn().
 				Err(err).
@@ -172,6 +189,10 @@ func (repo *ConceptMapRepository) GetConceptMapFileNameByURL(url string) (string
 			return nil // Continue walking even if one file fails
 		}
 
+		// TODO check if the targetUri check is a remnant of artdecor and should be removed?
+		// As targeturi should be the url of the value set and not the url of the conceptmap...
+		// TODO: check implications of stopping the walk when a match is found
+		// Supposedly url names are unique so it should be fine, but do we make sure url names are unique?
 		// Check both URL and TargetUri
 		if (conceptMap.Url != nil && *conceptMap.Url == url) ||
 			(conceptMap.TargetUri != nil && *conceptMap.TargetUri == url) {
@@ -195,4 +216,17 @@ func (repo *ConceptMapRepository) GetConceptMapFileNameByURL(url string) (string
 	}
 
 	return matchingFileName, nil
+}
+
+// GetAllConceptMapsFromCache returns all ConceptMaps in the repository, this is just used to check what is in cache
+// and not really needed functionality
+func (r *ConceptMapRepository) GetAllConceptMapsFromCache() []string {
+	var keys []string
+	r.cache.Range(func(key, value interface{}) bool {
+		keys = append(keys, key.(string))
+		return true
+	})
+
+	return keys
+
 }

--- a/cmd/fenix/fhir/conceptmap/repository.go
+++ b/cmd/fenix/fhir/conceptmap/repository.go
@@ -101,6 +101,8 @@ func (repo *ConceptMapRepository) GetConceptMap(url string) (*fhir.ConceptMap, e
 	if cached, ok := repo.cache.Load(url); ok {
 		return cached.(*fhir.ConceptMap), nil
 	}
+
+	return nil, fmt.Errorf("ConceptMap not found in cache for URL: %s", url)
 }
 
 // GetConceptMapURLsByValuesetURL retrieves all ConceptMaps with a target URI matching the input URL.

--- a/cmd/fenix/fhir/conceptmap/repository.go
+++ b/cmd/fenix/fhir/conceptmap/repository.go
@@ -75,7 +75,7 @@ func (repo *ConceptMapRepository) LoadConceptMapsIntoRepository() error {
 	return nil
 }
 
-// loadConceptMapFile loads a ConceptMap from a file.
+// readConceptMapFile reads a ConceptMap from a file.
 func (repo *ConceptMapRepository) readConceptMapFromFile(filePath string) (*fhir.ConceptMap, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {

--- a/cmd/fenix/fhir/conceptmap/repository.go
+++ b/cmd/fenix/fhir/conceptmap/repository.go
@@ -145,12 +145,6 @@ func (repo *ConceptMapRepository) GetConceptMapURLsByValuesetURL(valueSetURL str
 	return matchingConceptMapURLs, nil
 }
 
-// TODO check if this function is really needed, it seems not to be used anywhere
-// Helper function to get the file name for a ConceptMap by ID or URL.
-func (repo *ConceptMapRepository) getFileName(key string) string {
-	return fmt.Sprintf("%s.json", key)
-}
-
 // GetConceptMapFileNameByURL returns the filename of a ConceptMap based on its URL
 // This function is only called in the  GetOrLoadConceptMap function but I am not sure it is really needed there
 // It might however be usefull if you do not want to have all conceptmaps loaded at once but only the ones you need

--- a/cmd/fenix/fhir/conceptmap/repository.go
+++ b/cmd/fenix/fhir/conceptmap/repository.go
@@ -66,19 +66,6 @@ func (repo *ConceptMapRepository) LoadConceptMapsIntoRepository() error {
 					Str("file", file.Name()).
 					Msg("ConceptMap has no Url")
 			}
-
-			if conceptMap.TargetUri != nil {
-				if *conceptMap.TargetUri != "" {
-					repo.cache.Store(*conceptMap.TargetUri, conceptMap)
-					repo.log.Debug().
-						Str("targetUri", *conceptMap.TargetUri).
-						Msg("Loaded ConceptMap into cache by TargetUri")
-				}
-			} else {
-				repo.log.Warn().
-					Str("file", file.Name()).
-					Msg("ConceptMap has no TargetUri")
-			}
 		}
 	}
 

--- a/cmd/fenix/fhir/conceptmap/repository.go
+++ b/cmd/fenix/fhir/conceptmap/repository.go
@@ -13,21 +13,21 @@ import (
 )
 
 // TODO: think about when the cache should be cleared and how to do this
-// Every run / every request, ...? It seems now to collect conceptmaps from different dates and not to clear the cache
+// TODO: think about cache versus loading conceptmaps and how to do it comparable to the valueset repository
 // ConceptMapRepository handles loading and storing ConceptMap resources.
 type ConceptMapRepository struct {
-	log         zerolog.Logger
-	localPath   string
-	cache       sync.Map
-	conceptMaps map[string]fhir.ConceptMap
+	log       zerolog.Logger
+	localPath string
+	cache     sync.Map
+	//conceptMaps map[string]fhir.ConceptMap
 }
 
 // NewConceptMapRepository creates a new ConceptMapRepository.
 func NewConceptMapRepository(localPath string, log zerolog.Logger) *ConceptMapRepository {
 	return &ConceptMapRepository{
-		log:         log,
-		localPath:   localPath,
-		conceptMaps: make(map[string]fhir.ConceptMap),
+		log:       log,
+		localPath: localPath,
+		//conceptMaps: make(map[string]fhir.ConceptMap),
 	}
 }
 

--- a/cmd/fenix/fhir/conceptmap/repository.go
+++ b/cmd/fenix/fhir/conceptmap/repository.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// TODO add source or target in function names to make it more clear what the function does
 // ConceptMapRepository handles loading and storing ConceptMap resources.
 type ConceptMapRepository struct {
 	log         zerolog.Logger

--- a/cmd/fenix/fhir/conceptmap/repository.go
+++ b/cmd/fenix/fhir/conceptmap/repository.go
@@ -56,6 +56,8 @@ func (repo *ConceptMapRepository) LoadConceptMapsIntoRepository() error {
 				continue
 			}
 
+			// TODO: add check for empty string or make sure that the url is always present
+			// Also check this at other places where the url is used
 			if conceptMap.Url != nil {
 				repo.cache.Store(*conceptMap.Url, conceptMap)
 				repo.log.Debug().

--- a/cmd/fenix/fhir/conceptmap/repository.go
+++ b/cmd/fenix/fhir/conceptmap/repository.go
@@ -200,6 +200,7 @@ func (repo *ConceptMapRepository) GetConceptMapFileNameByURL(url string) (string
 	return matchingFileName, nil
 }
 
+// TODO: remove function and call in main when done?
 // GetAllConceptMapsFromCache returns all ConceptMaps in the repository, this is just used to check what is in cache
 // and not really needed functionality
 func (r *ConceptMapRepository) GetAllConceptMapsFromCache() []string {

--- a/cmd/fenix/fhir/conceptmap/repository.go
+++ b/cmd/fenix/fhir/conceptmap/repository.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// TODO: think about when the cache should be cleared and how to do this
+// Every run / every request, ...? It seems now to collect conceptmaps from different dates and not to clear the cache
 // ConceptMapRepository handles loading and storing ConceptMap resources.
 type ConceptMapRepository struct {
 	log         zerolog.Logger

--- a/cmd/fenix/fhir/conceptmap/service.go
+++ b/cmd/fenix/fhir/conceptmap/service.go
@@ -115,18 +115,3 @@ func getDisplayValue(display *string) string {
 func (svc *ConceptMapService) GetConceptMapURLsByValuesetURL(valueSetURL string) ([]string, error) {
 	return svc.repo.GetConceptMapURLsByValuesetURL(valueSetURL)
 }
-
-// TODO: check if needed, seems not used yet
-// Helper function to extract version from ConceptMap
-func getVersionFromConceptMap(cm *fhir.ConceptMap) string {
-	if cm.Version != nil {
-		return *cm.Version
-	}
-	return ""
-}
-
-// TODO: check if needed, seems not used yet
-// GetRepository returns the ConceptMapRepository
-func (s *ConceptMapService) GetRepository() *ConceptMapRepository {
-	return s.repo
-}

--- a/cmd/fenix/fhir/conceptmap/service.go
+++ b/cmd/fenix/fhir/conceptmap/service.go
@@ -21,12 +21,6 @@ func NewConceptMapService(repo *ConceptMapRepository, log zerolog.Logger) *Conce
 	}
 }
 
-// GetConceptMapForValueSet retrieves the ConceptMap for a given ValueSet URL.
-// TODO not sure if this function should be here
-func stringPtr(s string) *string {
-	return &s
-}
-
 // TODO think about a better name for this method, as not only codes are translated
 // It is also not clear if it is about code/coding/quantity, but also not because a coding contains a system code and display
 func (s *ConceptMapService) TranslateCode(conceptMapURLs []string, sourceCode string, typeIsCode bool) (*TranslationResult, error) {

--- a/cmd/fenix/fhir/conceptmap/service.go
+++ b/cmd/fenix/fhir/conceptmap/service.go
@@ -35,7 +35,7 @@ func (s *ConceptMapService) TranslateCode(conceptMapURLs []string, sourceCode st
 
 	// Try each concept map
 	for _, url := range conceptMapURLs {
-		conceptMap, err := s.repo.GetOrLoadConceptMap(url)
+		conceptMap, err := s.repo.GetConceptMap(url)
 		if err != nil {
 			s.log.Debug().Err(err).Str("url", url).Msg("Failed to get concept map, trying next")
 			continue

--- a/cmd/fenix/fhir/conceptmap/service.go
+++ b/cmd/fenix/fhir/conceptmap/service.go
@@ -1,11 +1,7 @@
 package conceptmap
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
-	"time"
 
 	"github.com/SanteonNL/fenix/models/fhir"
 	"github.com/rs/zerolog"
@@ -105,45 +101,6 @@ func (s *ConceptMapService) findDefaultMapping(conceptMap *fhir.ConceptMap) *Tra
 			}
 		}
 	}
-	return nil
-}
-
-// TODO: check if this is the best location, why not in the converter.go file?
-// What would be reassons to have it here?
-func (s *ConceptMapService) CreateConceptMap(id string, name string, sourceValueSet string, targetValueSet string) *fhir.ConceptMap {
-	url := fmt.Sprintf("http://localhost/fhir/ConceptMap/%s", id)
-
-	return &fhir.ConceptMap{
-		Id:        &id,
-		Url:       &url,
-		Name:      &name,
-		Status:    1,
-		Date:      stringPtr(time.Now().Format(time.RFC3339)),
-		SourceUri: &sourceValueSet,
-		TargetUri: &targetValueSet,
-		Group:     []fhir.ConceptMapGroup{},
-	}
-}
-
-// Add this method to your existing conceptmap/service.go file
-// TODO: check if this is the best location, why not in the converter.go file?
-// What would be reassons to have it here?
-func (s *ConceptMapService) SaveConceptMap(outputPath string, cm *fhir.ConceptMap) error {
-	data, err := json.MarshalIndent(cm, "", "  ")
-	if err != nil {
-		return fmt.Errorf("failed to marshal ConceptMap: %w", err)
-	}
-
-	if err := os.MkdirAll(filepath.Dir(outputPath), 0755); err != nil {
-		return fmt.Errorf("failed to create directories: %w", err)
-	}
-
-	if err := os.WriteFile(outputPath, data, 0644); err != nil {
-		s.log.Error().Err(err).Str("path", outputPath).Msg("Failed to write ConceptMap to file")
-		return fmt.Errorf("failed to write ConceptMap file: %w", err)
-	}
-
-	s.log.Debug().Str("path", outputPath).Msg("Successfully saved ConceptMap")
 	return nil
 }
 

--- a/cmd/fenix/fhir/conceptmap/service.go
+++ b/cmd/fenix/fhir/conceptmap/service.go
@@ -26,10 +26,13 @@ func NewConceptMapService(repo *ConceptMapRepository, log zerolog.Logger) *Conce
 }
 
 // GetConceptMapForValueSet retrieves the ConceptMap for a given ValueSet URL.
-
+// TODO not sure if this function should be here
 func stringPtr(s string) *string {
 	return &s
 }
+
+// TODO think about a better name for this method, as not only codes are translated
+// It is also not clear if it is about code/coding/quantity, but also not because a coding contains a system code and display
 func (s *ConceptMapService) TranslateCode(conceptMapURLs []string, sourceCode string, typeIsCode bool) (*TranslationResult, error) {
 	if len(conceptMapURLs) == 0 || sourceCode == "" {
 		return nil, fmt.Errorf("at least one conceptMap URL and sourceCode are required")
@@ -42,7 +45,7 @@ func (s *ConceptMapService) TranslateCode(conceptMapURLs []string, sourceCode st
 
 	// Try each concept map
 	for _, url := range conceptMapURLs {
-		conceptMap, err := s.repo.GetConceptMap(url)
+		conceptMap, err := s.repo.GetOrLoadConceptMap(url)
 		if err != nil {
 			s.log.Debug().Err(err).Str("url", url).Msg("Failed to get concept map, trying next")
 			continue
@@ -67,6 +70,7 @@ func (s *ConceptMapService) TranslateCode(conceptMapURLs []string, sourceCode st
 	return nil, nil
 }
 
+// TODO: Change name to something more descriptive
 func (s *ConceptMapService) findDirectMapping(conceptMap *fhir.ConceptMap, sourceCode string) *TranslationResult {
 	for _, group := range conceptMap.Group {
 		for _, element := range group.Element {
@@ -85,6 +89,7 @@ func (s *ConceptMapService) findDirectMapping(conceptMap *fhir.ConceptMap, sourc
 	return nil
 }
 
+// TODO: change name, it is not a default mapping but a wildcard mapping
 func (s *ConceptMapService) findDefaultMapping(conceptMap *fhir.ConceptMap) *TranslationResult {
 	for _, group := range conceptMap.Group {
 		for _, element := range group.Element {
@@ -103,6 +108,8 @@ func (s *ConceptMapService) findDefaultMapping(conceptMap *fhir.ConceptMap) *Tra
 	return nil
 }
 
+// TODO: check if this is the best location, why not in the converter.go file?
+// What would be reassons to have it here?
 func (s *ConceptMapService) CreateConceptMap(id string, name string, sourceValueSet string, targetValueSet string) *fhir.ConceptMap {
 	url := fmt.Sprintf("http://localhost/fhir/ConceptMap/%s", id)
 
@@ -119,7 +126,8 @@ func (s *ConceptMapService) CreateConceptMap(id string, name string, sourceValue
 }
 
 // Add this method to your existing conceptmap/service.go file
-
+// TODO: check if this is the best location, why not in the converter.go file?
+// What would be reassons to have it here?
 func (s *ConceptMapService) SaveConceptMap(outputPath string, cm *fhir.ConceptMap) error {
 	data, err := json.MarshalIndent(cm, "", "  ")
 	if err != nil {
@@ -147,10 +155,11 @@ func getDisplayValue(display *string) string {
 	return ""
 }
 
-func (svc *ConceptMapService) GetConceptMapsByValuesetURL(valueSetURL string) ([]string, error) {
-	return svc.repo.GetConceptMapsByValuesetURL(valueSetURL)
+func (svc *ConceptMapService) GetConceptMapURLsByValuesetURL(valueSetURL string) ([]string, error) {
+	return svc.repo.GetConceptMapURLsByValuesetURL(valueSetURL)
 }
 
+// TODO: check if needed, seems not used yet
 // Helper function to extract version from ConceptMap
 func getVersionFromConceptMap(cm *fhir.ConceptMap) string {
 	if cm.Version != nil {
@@ -159,6 +168,7 @@ func getVersionFromConceptMap(cm *fhir.ConceptMap) string {
 	return ""
 }
 
+// TODO: check if needed, seems not used yet
 // GetRepository returns the ConceptMapRepository
 func (s *ConceptMapService) GetRepository() *ConceptMapRepository {
 	return s.repo

--- a/cmd/fenix/fhir/fhirpathinfo/service.go
+++ b/cmd/fenix/fhir/fhirpathinfo/service.go
@@ -77,7 +77,7 @@ func (svc *PathInfoService) BuildIndex() error {
 			info.ValueSet = valueSetURL
 
 			// Then find all ConceptMaps that reference this ValueSet
-			conceptMaps, err := svc.conceptMapService.GetConceptMapsByValuesetURL(valueSetURL)
+			conceptMaps, err := svc.conceptMapService.GetConceptMapURLsByValuesetURL(valueSetURL)
 			if err != nil {
 				svc.log.Warn().
 					Err(err).

--- a/cmd/fenix/fhir/valueset/service.go
+++ b/cmd/fenix/fhir/valueset/service.go
@@ -372,6 +372,7 @@ func (s *ValueSetService) getValueSetFilename(valueSet *fhir.ValueSet) string {
 	return fmt.Sprintf("%s_%s.json", baseName, urlHash)
 }
 
+// TODO: Add check if valueset needs to be updated? Or is it already somewhere else?
 // WriteNewValueSet writes a newly downloaded ValueSet to disk and updates mappings
 func (s *ValueSetService) WriteNewValueSet(ctx context.Context, valueSet *fhir.ValueSet) error {
 	if valueSet.Url == nil {

--- a/cmd/fenix/main.go
+++ b/cmd/fenix/main.go
@@ -43,21 +43,20 @@ func main() {
 		log.Fatal().Err(err).Msg("Failed to connect to database")
 	}
 
+	// Convert CSV conceptmaps to FHIR ConceptMaps
 	conceptMapConverter, err := conceptmap.NewConceptMapConverter(log)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialize ConceptMapConverter")
 	}
-	// Initialize conceptmap repository and converter
 	conceptMapRepo := conceptmap.NewConceptMapRepository(conceptMapConverter.RepositoryDir, log)
 
-	// Process ConceptMap CSV files and convert them to FHIR ConceptMaps
 	log.Info().
 		Str("input_directory", conceptMapConverter.InputDir).
 		Str("repository_directory", conceptMapConverter.RepositoryDir).
 		Msg("Starting the conversion of ConceptMap CSV files to JSON format")
 
-	// Set usePrefix to true to add 'conceptmap_converted_' prefix to ValueSet URIs
-	if err := conceptMapConverter.ConvertFolderToFHIR(conceptMapConverter.InputDir, conceptMapRepo, true); err != nil {
+	usePrefix := true // Set usePrefix to true to add 'conceptmap_converted_' prefix to ValueSet URIs
+	if err := conceptMapConverter.ConvertFolderToFHIR(conceptMapConverter.InputDir, conceptMapRepo, usePrefix); err != nil {
 		log.Error().Err(err).Msg("Conversion process failed")
 		os.Exit(1)
 	}

--- a/cmd/fenix/main.go
+++ b/cmd/fenix/main.go
@@ -45,9 +45,9 @@ func main() {
 	}
 
 	// Define paths
-	baseDir := "."                                                // Current directory
-	inputDir := filepath.Join(baseDir, "config/conceptmaps/flat") // ./csv directory for input files
-	repoDir := filepath.Join(baseDir, "config/conceptmaps")       // ./fhir directory for repository
+	baseDir := "."                                                         // Current directory
+	inputDir := filepath.Join(baseDir, "config/conceptmaps/flat")          // ./csv directory for input files
+	repoDir := filepath.Join(baseDir, "config/conceptmaps/fhir/converted") // ./fhir directory for repository
 
 	// Initialize repository
 	repository := conceptmap.NewConceptMapRepository(repoDir, log)

--- a/cmd/fenix/main.go
+++ b/cmd/fenix/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/SanteonNL/fenix/cmd/fenix/api"
@@ -44,37 +43,40 @@ func main() {
 		log.Fatal().Err(err).Msg("Failed to connect to database")
 	}
 
-	// Define paths
-	baseDir := "."                                                         // Current directory
-	inputDir := filepath.Join(baseDir, "config/conceptmaps/flat")          // ./csv directory for input files
-	repoDir := filepath.Join(baseDir, "config/conceptmaps/fhir/converted") // ./fhir directory for repository
-
-	// Initialize repository
-	repository := conceptmap.NewConceptMapRepository(repoDir, log)
-
-	// Load existing concept maps
-	if err := repository.LoadConceptMapsIntoRepository(); err != nil {
-		log.Error().Err(err).Msg("Failed to load existing concept maps")
-		os.Exit(1)
+	conceptMapConverter, err := conceptmap.NewConceptMapConverter(log)
+	if err != nil {
+		log.Fatal().Err(err).Msg("Failed to initialize ConceptMapConverter")
 	}
+	// Initialize conceptmap repository and converter
+	conceptMapRepo := conceptmap.NewConceptMapRepository(conceptMapConverter.RepositoryDir, log)
 
-	// Initialize services and converter
-	conceptMapService := conceptmap.NewConceptMapService(repository, log)
-	conceptMapConverter := conceptmap.NewConceptMapConverter(log, conceptMapService)
-
-	// Process the input directory
+	// Process ConceptMap CSV files and convert them to FHIR ConceptMaps
 	log.Info().
-		Str("input_dir", inputDir).
-		Str("repo_dir", repoDir).
-		Msg("Starting conversion of CSV files")
+		Str("input_directory", conceptMapConverter.InputDir).
+		Str("repository_directory", conceptMapConverter.RepositoryDir).
+		Msg("Starting the conversion of ConceptMap CSV files to JSON format")
 
 	// Set usePrefix to true to add 'conceptmap_converted_' prefix to ValueSet URIs
-	if err := conceptMapConverter.ConvertFolderToFHIR(inputDir, repository, true); err != nil {
+	if err := conceptMapConverter.ConvertFolderToFHIR(conceptMapConverter.InputDir, conceptMapRepo, true); err != nil {
 		log.Error().Err(err).Msg("Conversion process failed")
 		os.Exit(1)
 	}
 
 	log.Info().Msg("Successfully completed conversion process")
+
+	// Load all conceptmaps into the repository
+	if err := conceptMapRepo.LoadConceptMapsIntoRepository(); err != nil {
+		log.Error().Err(err).Msg("Failed to load existing concept maps")
+		os.Exit(1)
+	}
+
+	// Initialize services
+
+	conceptMapService := conceptmap.NewConceptMapService(conceptMapRepo, log)
+
+	for _, conceptMap := range conceptMapRepo.GetAllConceptMapsFromCache() {
+		log.Info().Msgf("ConceptMap: %s", conceptMap)
+	}
 
 	dataSourceService := datasource.NewDataSourceService(db, log)
 	// Load queries

--- a/cmd/fenix/main.go
+++ b/cmd/fenix/main.go
@@ -53,7 +53,7 @@ func main() {
 	repository := conceptmap.NewConceptMapRepository(repoDir, log)
 
 	// Load existing concept maps
-	if err := repository.LoadConceptMaps(); err != nil {
+	if err := repository.LoadConceptMapsIntoRepository(); err != nil {
 		log.Error().Err(err).Msg("Failed to load existing concept maps")
 		os.Exit(1)
 	}
@@ -100,9 +100,9 @@ func main() {
 	// Example: Find ConceptMaps for a specific ValueSet
 	valueSetURL := "https://decor.nictiz.nl/fhir/4.0/sansa-/ValueSet/2.16.840.1.113883.2.4.3.11.60.909.11.2--20241203090354"
 
-	conceptMapService.GetConceptMapsByValuesetURL(valueSetURL)
+	conceptMapService.GetConceptMapURLsByValuesetURL(valueSetURL)
 
-	conceptMaps, err := conceptMapService.GetConceptMapsByValuesetURL(valueSetURL)
+	conceptMaps, err := conceptMapService.GetConceptMapURLsByValuesetURL(valueSetURL)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to get ConceptMaps")
 	} else {

--- a/cmd/fenix/output/temp/20250102_123157/logs/app.log
+++ b/cmd/fenix/output/temp/20250102_123157/logs/app.log
@@ -1,3 +1,0 @@
-{"level":"debug","time":"2025-01-02T12:31:57+01:00","caller":"C:/Users/t.hetterscheid/Repos/fenix/cmd/fenix/main.go:39","message":"Starting fenix"}
-{"level":"error","error":"open config\\conceptmaps\\fhir\\converted: The system cannot find the path specified.","time":"2025-01-02T12:31:57+01:00","caller":"C:/Users/t.hetterscheid/Repos/fenix/cmd/fenix/fhir/conceptmap/repository.go:36","message":"Failed to read directory"}
-{"level":"error","error":"failed to read directory: open config\\conceptmaps\\fhir\\converted: The system cannot find the path specified.","time":"2025-01-02T12:31:57+01:00","caller":"C:/Users/t.hetterscheid/Repos/fenix/cmd/fenix/main.go:57","message":"Failed to load existing concept maps"}

--- a/cmd/fenix/processor/populate.go
+++ b/cmd/fenix/processor/populate.go
@@ -464,9 +464,9 @@ func (p *ProcessorService) setCodingOrQuantityFromRow(valuesetBindingPath string
 			return nil
 		}
 		coding := fhir.Coding{
-			Code:    stringPtr(code),
-			Display: stringPtr(fieldValues["display"]),
-			System:  stringPtr(system),
+			Code:    stringPtrOrNil(code),
+			Display: stringPtrOrNil(fieldValues["display"]),
+			System:  stringPtrOrNil(system),
 		}
 
 		// // Handle concept mapping
@@ -482,9 +482,9 @@ func (p *ProcessorService) setCodingOrQuantityFromRow(valuesetBindingPath string
 	} else {
 		quantity := fhir.Quantity{
 			Value:  jsonNumberPtr(fieldValues["value"]),
-			Unit:   stringPtr(fieldValues["unit"]),
-			System: stringPtr(system),
-			Code:   stringPtr(code),
+			Unit:   stringPtrOrNil(fieldValues["unit"]),
+			System: stringPtrOrNil(system),
+			Code:   stringPtrOrNil(code),
 		}
 
 		// if code != "" {
@@ -629,7 +629,8 @@ func jsonNumberPtr(s string) *json.Number {
 }
 
 // Helper function to set a string pointer if the value is not empty
-func stringPtr(s string) *string {
+// TODO: check of this function can also be used for  StringPtr function that is now in utils.go
+func stringPtrOrNil(s string) *string {
 	if s == "" {
 		return nil
 	}

--- a/cmd/fenix/processor/populate.go
+++ b/cmd/fenix/processor/populate.go
@@ -708,7 +708,7 @@ func (rp *ProcessorService) setField(structPath string, structPtr interface{}, f
 
 		rp.log.Debug().Msgf("binding ValueSet: %s", bindingValueSet)
 
-		conceptMapURL, err := rp.conceptMapSvc.GetConceptMapsByValuesetURL(bindingValueSet)
+		conceptMapURL, err := rp.conceptMapSvc.GetConceptMapURLsByValuesetURL(bindingValueSet)
 		if err != nil {
 			rp.log.Error().Err(err).Msg("Failed to get ConceptMap")
 		}

--- a/util/utils.go
+++ b/util/utils.go
@@ -19,6 +19,7 @@ func GetAbsolutePath(relativePath string) string {
 	return absolutePath
 }
 
+// TODO: check of this function can be removed and use StringPtrOrNil instead that is now definied in populate.go
 func StringPtr(s string) *string {
 	return &s
 }


### PR DESCRIPTION
- Restructured main.go
    - conceptmaps are first converted from csv to fhir and then al conceptmaps are loaded in the repository

- Renamed functions 
    - LoadConceptMaps to LoadConceptMapsIntoRepository
    - loadConceptMapFile to readConceptMapFromFile
    - GetConceptMapsByValuesetURL to GetConceptMapURLsByValuesetURL
    - 
- Moved functions and functionality
    - setting the repository directories is moved from main to converter.go
    - make converter independent of conceptmapservice, so moved SaveConceptmap and CreateConceptmap from service to converter
- Deleted unused functions
    - ConvertCSVToFHIR
    - getFileName (not used anymore because of simplification GetConceptmap)
    - 
- Added functions
    - SetupDirectories 
        - If repository directories  do not exist yet they are created
- Simplified functions
    - Only conceptmap.Url is added to cache not id or targetUri anymore, and also only in LoadConceptmapToRepository, not anymore in GetConceptmap or the concerter.
    - Removed loadingfrom disk from GetConceptMap, because this can be done by LoadConceptMapsIntoRepository for aall conceptmaps at once